### PR TITLE
update params for htmlcoin testnet

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -151,8 +151,8 @@ var livenet = get('livenet');
 addNetwork({
   name: 'testnet',
   alias: 'regtest',
-  pubkeyhash: 0x78,
-  privatekey: 0xef,
+  pubkeyhash: 0x64,
+  privatekey: 0xe4,
   scripthash: 0x6e,
   xpubkey: 0x043587cf,
   xprivkey: 0x04358394


### PR DESCRIPTION
htmlcoincore-node run testnet incorrectly because of wrong net params.